### PR TITLE
SF patch #3 opened 2015-06-16 moved to github: P300 setaddr patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,6 @@ add_executable(vclient ${vclient_SRCS})
 
 add_executable(vsim ${vsim_SRCS})
 
-install(TARGETS vcontrold DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS vcontrold DESTINATION ${CMAKE_INSTALL_PREFIX}/sbin)
 install(TARGETS vclient DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(TARGETS vsim DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)


### PR DESCRIPTION
I fixed the P300 setaddr command, which send the data (SEND BYTES) after the checksum. Because framer_send() can be called several times before the message is complete, I moved sending the checksum to framer_receive() instead of framer_send() and using a local static variable to calculate the checksum step by step. Workes fine with my device ID="20CB" name="VScotHO1". Did not yet test the KW protocol again (hope my changes do not break that).

Also fixed that P300 code produced lots of logging output without debug (-g) set.

Please test the code and write results here. Hope that it finds it's way to the official trunk if everything works fine.

For more details and old feedback see also [SF Patch #3](https://sourceforge.net/p/vcontrold/patches/3/)

Unfortunately SF change r106 to r107 by fnobis in parser.c, execByteCode(), starting line 181 broke my setaddr patch again. For now I have undone this change. Need discussion with Frank, why he needed the change. But currently he is not active any more ...

Cheers, Holger