### PR TITLE
remove misleading unevaluated access check

### DIFF
--- a/doc/examples/vcontrold.xml
+++ b/doc/examples/vcontrold.xml
@@ -7,9 +7,6 @@
 	</serial>
 	<net>
 		<port>3002</port>
-		<allow ip='127.0.0.1'/>
-		<allow ip='192.168.1.0/24'/>
-
 	</net>
 	<logging>
 		<file>/tmp/vcontrold.log</file>

--- a/src/socket.c
+++ b/src/socket.c
@@ -126,7 +126,7 @@ int openSocket(int tcpport)
     return listenfd;
 }
 
-int listenToSocket(int listenfd, int makeChild, short (*checkP)(char *))
+int listenToSocket(int listenfd, int makeChild)
 {
     int connfd;
     pid_t childpid;

--- a/src/socket.h
+++ b/src/socket.h
@@ -20,7 +20,7 @@
 #include <arpa/inet.h>
 
 int openSocket(int tcpport);
-int listenToSocket(int listenfd, int makeChild, short (*checkP)(char *));
+int listenToSocket(int listenfd, int makeChild);
 int openCliSocket(char *host, int port, int noTCPdelay);
 void closeSocket(int sockfd);
 

--- a/src/vcontrold.c
+++ b/src/vcontrold.c
@@ -76,7 +76,6 @@ void printHelp(int socketfd);
 int rawModus (int socketfd, char *device);
 static void sigPipeHandler(int signo);
 static void sigHupHandler(int signo);
-short checkIP(char *ip);
 int reloadConfig();
 
 void usage()
@@ -92,19 +91,6 @@ void usage()
     printf("                 [-4|--inet4] [-6|--inet6]\n\n");
 
     exit(1);
-}
-
-short checkIP(char *ip)
-{
-    allowPtr aPtr;
-
-    if ((aPtr = getAllowNode(cfgPtr->aPtr, inet_addr(ip)))) {
-        logIT(LOG_INFO, "%s in allowList (%s)", ip, aPtr->text);
-        return 1;
-    } else {
-        logIT(LOG_INFO, "%s not in allowList", ip);
-        return 0;
-    }
 }
 
 int reloadConfig()
@@ -889,18 +875,7 @@ int main(int argc, char *argv[])
         }
 
         int sockfd = -1;
-        int listenfd = -1;
-        // Pointer to the checkIP function
-        short (*checkP)(char *);
-
-        if (cfgPtr->aPtr) {
-            // We have an allow list
-            checkP = checkIP;
-        } else {
-            checkP = NULL;
-        }
-
-        listenfd = openSocket(tcpport);
+        int listenfd = openSocket(tcpport);
 
         // Drop privileges after binding
         if (0 == getuid()) {
@@ -966,7 +941,7 @@ int main(int argc, char *argv[])
         vcontrol_seminit();
 
         while (1) {
-            sockfd = listenToSocket(listenfd, makeDaemon, checkP);
+            sockfd = listenToSocket(listenfd, makeDaemon);
             if (signal(SIGPIPE, sigPipeHandler) == SIG_ERR) {
                 logIT1(LOG_ERR, "Signal error");
                 exit(1);

--- a/src/vsim.c
+++ b/src/vsim.c
@@ -41,13 +41,11 @@
 #define SERVERPORT 6578
 int makeDaemon = 0;
 int inetversion = 0;
-short (*checkP)(char *) = NULL;
 int readCmdFile(char *filename, char *result, int *resultLen, char *device );
 int interactive(int socketfd, char *device);
 void printHelp(int socketfd);
 int rawModus (int socketfd, char *device);
 static void sigPipeHandler(int signo);
-short checkIP(char *ip);
 
 void logIT (int class, char *string, ...)
 {
@@ -158,7 +156,7 @@ int main(int argc, char *argv[])
 
     listenfd = openSocket(SERVERPORT);
     while (1) {
-        sockfd = listenToSocket(listenfd, makeDaemon, checkP);
+        sockfd = listenToSocket(listenfd, makeDaemon);
         if (signal(SIGPIPE, sigPipeHandler) == SIG_ERR) {
             logIT(LOG_ERR, "Signal error");
             exit(1);

--- a/src/xmlconfig.c
+++ b/src/xmlconfig.c
@@ -42,7 +42,6 @@ void removeMacroList(macroPtr ptr);
 void removeCommandList(commandPtr ptr);
 void removeDeviceList(devicePtr ptr);
 void removeIcmdList(icmdPtr ptr);
-void removeAllowList(allowPtr ptr);
 void removeEnumList(enumPtr ptr);
 void freeAllLists();
 
@@ -385,51 +384,6 @@ void removeIcmdList(icmdPtr ptr)
     }
 }
 
-allowPtr getAllowNode(allowPtr ptr, const in_addr_t testIP)
-{
-    if (! ptr) {
-        return NULL;
-    }
-
-    if ((ntohl(ptr->ip) & ptr->mask) == (ntohl(testIP) & ptr->mask)) {
-        return ptr;
-    }
-
-    return getAllowNode(ptr->next, testIP);
-}
-
-allowPtr newAllowNode(allowPtr ptr)
-{
-    allowPtr nptr;
-    if (ptr && ptr->next) {
-        return newAllowNode(ptr->next);
-    }
-
-    nptr = calloc(1, sizeof(Allow));
-    if (! nptr) {
-        fprintf(stderr, "malloc failed\n");
-        exit(1);
-    }
-
-    if (ptr) {
-        ptr->next = nptr;
-    }
-
-    return nptr;
-}
-
-void removeAllowList(allowPtr ptr)
-{
-    if (ptr && ptr->next) {
-        removeAllowList(ptr->next);
-    }
-
-    if (ptr) {
-        free(ptr->text);
-        free(ptr);
-    }
-}
-
 enumPtr newEnumNode(enumPtr ptr)
 {
     enumPtr nptr;
@@ -555,14 +509,12 @@ configPtr parseConfig(xmlNodePtr cur)
     char *chrPtr;
     xmlNodePtr prevPtr;
     //char string[256];
-    allowPtr aPtr;
     char ip[16];
 
     cfgPtr = calloc(1, sizeof(Config));
     cfgPtr->port = 0;
     cfgPtr->syslog = 0;
     cfgPtr->debug = 0;
-    cfgPtr->aPtr = NULL;
 
     while (cur) {
         logIT(LOG_INFO, "CONFIG:(%d) Node::Name=%s Type:%d Content=%s",
@@ -650,60 +602,6 @@ configPtr parseConfig(xmlNodePtr cur)
             }
             (cur->next && (! (cur->next->type == XML_TEXT_NODE) || cur->next->next))
                 ? (cur = cur->next) : (cur = prevPtr->next);
-        } else if (netFound && strstr((char *)cur->name, "allow"))  {
-            chrPtr = getPropertyNode(cur->properties, (xmlChar *)"ip");
-            logIT(LOG_INFO, "   (%d) Node::Name=%s Type:%d Content=%s", cur->line, cur->name, cur->type, chrPtr);
-
-            // We now disassemble chrPtr to ip/size.
-            // If no mask is given, we assume /32.
-            // Afterwards, we build an inverse mask and put it in mask.
-            // ip == text content ip address mask == bitmask
-
-            char *ptr;
-            short count;
-            short size;
-            in_addr_t mask;
-
-            bzero(ip, sizeof(ip));
-            //bzero(string,sizeof(string));
-            if ((ptr = strchr(chrPtr, '/'))) {
-#if 0
-                strncpy(string, ptr + 1, sizeof(string) - 1);
-                size = atoi(string);
-#endif
-                size = atoi(ptr + 1);
-                strncpy(ip, chrPtr, ptr - chrPtr);
-            } else {
-                strncpy(ip, chrPtr, sizeof(ip) - 1);
-                size = 32;
-            }
-
-            if (inet_addr(ip) != INADDR_NONE) {
-                aPtr = newAllowNode(cfgPtr->aPtr);
-                aPtr->text = calloc(strlen(chrPtr) + 1, sizeof(char));
-                strcpy(aPtr->text, chrPtr);
-                mask = 0;
-                // We assemble a bitmask
-                if (size) {
-                    mask = 0x80000000;
-                    for (count = 0; count < size - 1; count++) {
-                        mask >>= 1;
-                        mask |= 0x80000000;
-                    }
-                }
-                aPtr->mask = mask;
-                aPtr->ip = inet_addr(ip);
-
-                if (! cfgPtr->aPtr) {
-                    cfgPtr->aPtr = aPtr;
-                }
-
-                logIT(LOG_INFO, "     Allow IP:%s Size:/%d", ip, size);
-            }
-
-            (cur->next && (! (cur->next->type == XML_TEXT_NODE) || cur->next->next))
-                ? (cur = cur->next) : (cur = prevPtr->next);
-
         } else if (logFound && strstr((char *)cur->name, "file")) {
             chrPtr = getTextNode(cur);
             logIT(LOG_INFO, "   (%d) Node::Name=%s Type:%d Content=%s",
@@ -1592,7 +1490,6 @@ void freeAllLists()
         free(cfgPtr->tty);
         free(cfgPtr->logfile);
         free(cfgPtr->devID);
-        removeAllowList(cfgPtr->aPtr);
         free(cfgPtr);
         cfgPtr = NULL;
     }

--- a/src/xmlconfig.h
+++ b/src/xmlconfig.h
@@ -34,16 +34,8 @@ int parseXMLFile(char *filename);
 macroPtr getMacroNode(macroPtr ptr, const char *name);
 unitPtr getUnitNode(unitPtr ptr, const char *name);
 commandPtr getCommandNode(commandPtr ptr, const char *name);
-allowPtr getAllowNode(allowPtr ptr, in_addr_t testIP);
 enumPtr getEnumNode(enumPtr prt, char *search, int len);
 icmdPtr getIcmdNode(icmdPtr ptr, const char *name);
-
-struct allow {
-    char *text;
-    in_addr_t ip;
-    in_addr_t mask;
-    allowPtr next;
-} Allow;
 
 struct compile {
     int token;
@@ -63,7 +55,6 @@ struct config {
     char *groupname;
     char *devID;
     devicePtr devPtr;
-    allowPtr aPtr;
     int syslog;
     int debug;
 } Config;

--- a/xml/300/vcontrold.xml
+++ b/xml/300/vcontrold.xml
@@ -13,8 +13,6 @@
       </serial>
       <net>
         <port>3002</port>
-        <allow ip="127.0.0.1"/>
-        <allow ip="192.168.1.0/24"/>
       </net>
       <logging>
         <file>vcontrold.log</file>

--- a/xml/kw/vcontrold.xml
+++ b/xml/kw/vcontrold.xml
@@ -7,8 +7,6 @@
       </serial>
       <net>
         <port>3002</port>
-        <allow ip="127.0.0.1"/>
-        <allow ip="192.168.1.0/24"/>
       </net>
       <logging>
         <file>/tmp/vcontrold.log</file>


### PR DESCRIPTION
The "allow ip" nodes from config are parsed but evaluated for access control, instead it is suggested to install a local firewall. The xml-nodes are misleading for beginners and may lead out to security issues, see #54. So I propose to remove these settings.