### PR TITLE
Use an iterative method for expanding commands now

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -436,14 +436,6 @@ void removeCompileList(compilePtr ptr)
 
 int expand(commandPtr cPtr, protocolPtr pPtr)
 {
-    // Recursion
-    if (! cPtr) {
-        return 0;
-    }
-    if (cPtr->next) {
-        expand(cPtr->next, pPtr);
-    }
-
     // If no address has been set, we do nothing
     if (! cPtr->addr) {
         return 0;
@@ -575,16 +567,17 @@ int expand(commandPtr cPtr, protocolPtr pPtr)
     return 1;
 }
 
+void expandAll(commandPtr cPtr, protocolPtr pPtr)
+{
+    // Start iteration
+    commandPtr curPtr = cPtr;
+    for (; curPtr; curPtr = curPtr->next) {
+        expand(curPtr, pPtr);
+    }
+}
+
 compilePtr buildByteCode(commandPtr cPtr, unitPtr uPtr)
 {
-    // Recursion
-    if (!cPtr) {
-        return 0;
-    }
-    if (cPtr->next) {
-        buildByteCode(cPtr->next, uPtr);
-    }
-
     // If no address has been given, we do nothing
     if (! cPtr->addr) {
         return 0;
@@ -650,16 +643,31 @@ compilePtr buildByteCode(commandPtr cPtr, unitPtr uPtr)
     return cmpStartPtr;
 }
 
+void buildByteCodeAll(commandPtr cPtr, unitPtr uPtr)
+{
+    // Start iteration
+    commandPtr curPtr = cPtr;
+    for (; curPtr; curPtr = curPtr->next) {
+        buildByteCode(curPtr, uPtr);
+    }
+}
+
 void compileCommand(devicePtr dPtr, unitPtr uPtr)
+{
+    logIT(LOG_INFO, "Expanding command for device %s", dPtr->id);
+    expandAll(dPtr->cmdPtr, dPtr->protoPtr);
+    buildByteCodeAll(dPtr->cmdPtr, uPtr);
+}
+
+void compileCommandAll(devicePtr dPtr, unitPtr uPtr)
 {
     if (! dPtr) {
         return;
     }
-    if (dPtr->next) {
-        compileCommand(dPtr->next, uPtr);
-    }
 
-    logIT(LOG_INFO, "Expanding command for device %s", dPtr->id);
-    expand(dPtr->cmdPtr, dPtr->protoPtr);
-    buildByteCode(dPtr->cmdPtr, uPtr);
+    // Start iteration
+    devicePtr curPtr = dPtr;
+    for (; curPtr; curPtr = curPtr->next) {
+        compileCommand(curPtr, uPtr);
+    }
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -11,7 +11,7 @@ void removeCompileList(compilePtr ptr);
 int execByteCode(compilePtr cmpPtr, int fd, char *recvBuf, short recvLen, char *sendBuf,
                  short sendLen, short supressUnit, char bitpos, int retry, char *pRecvPtr,
                  unsigned short recvTimeout);
-void compileCommand(devicePtr dPtr, unitPtr uPtr);
+void compileCommandAll(devicePtr dPtr, unitPtr uPtr);
 
 // Token Definition
 #define WAIT    1

--- a/src/vcontrold.c
+++ b/src/vcontrold.c
@@ -86,7 +86,7 @@ void usage()
 int reloadConfig()
 {
     if (parseXMLFile(xmlfile)) {
-        compileCommand(devPtr, uPtr);
+        compileCommandAll(devPtr, uPtr);
         logIT(LOG_NOTICE, "XML file %s reloaded", xmlfile);
         return 1;
     } else {
@@ -803,7 +803,7 @@ int main(int argc, char *argv[])
     }
 
     // The macros are replaced and the strings to send are converted to bytecode
-    compileCommand(devPtr, uPtr);
+    compileCommandAll(devPtr, uPtr);
 
     int fd = 0;
     char result[MAXBUF];


### PR DESCRIPTION
This merge request switches the methods "expand, buildByteCode and compileCommand" to using an iterative approach. I understand that the recursive approach used so far, looks more elegant at first glance. But it can give problems in the form of segfaults (see background story below) when trying to parse and process a large number of commands from a config file.
Switching to an iterative method introduces the "*All" wrapper methods to the source base (not so nice), but makes the overall process of parsing commands more robust (very nice).

Background: I'm currently starting to use vcontrold/vclient for monitoring and controlling my Vitodens200 (WBC2). Since I still don't know a few of the memory addresses, I wrote a Python script that can generate a "special" `vito.xml`. In this `vito.xml` I will define a single command "getVitoXXXX" for each address in a configurable range (see `create_shell.py` and `create_vito.py` in "scripts" folder of https://github.com/dirkbaechle/pyvctrl ). By checking all memory addresses before and after I changed the wanted values at the Vitodens200 directly, I can then do a simple diff to find the memory addresses by brute-force. When starting the `vcontrold` daemon with a `vito.xml` file for the addresses 0x2000-0x4000 (yes, that's a lot) the process crashes on my mini laptop (Samsung EE PC, 32bit, 2GB RAM, Linux Mint 19.3).
With the code from this branch `vcontrold` is running fine...