### PR TITLE
Fix possible problems detected via CodeQL codescanning workflow

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -252,7 +252,7 @@ int receive_nb(int fd, char *r_buf, int r_len, unsigned long *etime)
         if (retval == 0) {
             logIT(LOG_ERR, "<RECV: read timeout");
             setblock(fd);
-            logIT(LOG_INFO, dump(string, "<RECV: received", r_buf, i));
+            logIT(LOG_INFO, "%s", dump(string, "<RECV: received", r_buf, i));
             return -1;
         } else if (retval < 0) {
             if (errno == EINTR) {
@@ -261,7 +261,7 @@ int receive_nb(int fd, char *r_buf, int r_len, unsigned long *etime)
             } else {
                 logIT(LOG_ERR, "<RECV: select error %d", retval);
                 setblock(fd);
-                logIT(LOG_INFO, dump(string, "<RECV: received", r_buf, i));
+                logIT(LOG_INFO, "%s", dump(string, "<RECV: received", r_buf, i));
                 return -1;
             }
         } else if ( FD_ISSET(fd, &rfds)) {
@@ -269,7 +269,7 @@ int receive_nb(int fd, char *r_buf, int r_len, unsigned long *etime)
             if (len == 0) {
                 logIT(LOG_ERR, "<RECV: read eof");
                 setblock(fd);
-                logIT(LOG_INFO, dump(string, "<RECV: received", r_buf, i));
+                logIT(LOG_INFO, "%s", dump(string, "<RECV: received", r_buf, i));
                 return -1;
             } else if (len < 0) {
                 if (errno == EINTR) {
@@ -278,7 +278,7 @@ int receive_nb(int fd, char *r_buf, int r_len, unsigned long *etime)
                 } else {
                     logIT(LOG_ERR, "<RECV: read error %d", errno);
                     setblock(fd);
-                    logIT(LOG_INFO, dump(string, "<RECV: received", r_buf, i));
+                    logIT(LOG_INFO, "%s", dump(string, "<RECV: received", r_buf, i));
                     return -1;
                 }
             } else {
@@ -296,7 +296,7 @@ int receive_nb(int fd, char *r_buf, int r_len, unsigned long *etime)
     end = times(&tms_t);
     *etime = ((float)(end - start) / clktck) * 1000;
     setblock(fd);
-    logIT(LOG_INFO, dump(string, "<RECV: received", r_buf, i));
+    logIT(LOG_INFO, "%s", dump(string, "<RECV: received", r_buf, i));
 
     return i;
 }
@@ -316,7 +316,7 @@ int waitfor(int fd, char *w_buf, int w_len)
     unsigned long etime;
 
     for (i = 0; i < w_len; i++) {
-        sprintf(dummy, "%02X", w_buf[i]);
+        sprintf(dummy, "%02hhX", w_buf[i]);
         strncat(hexString, dummy, strlen(dummy));
     }
 

--- a/src/vcontrold.c
+++ b/src/vcontrold.c
@@ -891,11 +891,13 @@ int main(int argc, char *argv[])
                 exit(1);
             }
 
+            int logfd = open(logfile, O_CREAT | O_RDONLY, S_IRUSR | S_IWUSR);
             // Make logfile accessible to the anticipated user/group
-            if (stat(logfile, &stb) == 0) {
-                chmod(logfile, stb.st_mode | S_IRGRP | S_IWGRP);
-                chown(logfile, pw->pw_uid, grp->gr_gid);
+            if ((logfd >= 0) && (fstat(logfd, &stb) == 0)) {
+                fchmod(logfd, stb.st_mode | S_IRGRP | S_IWGRP);
+                fchown(logfd, pw->pw_uid, grp->gr_gid);
             }
+            close(logfd);
             // Make lock file accessible to the anticipated user/group
             if (stat(tmpfilename, &stb) == 0) {
                 chmod(tmpfilename, stb.st_mode | S_IRGRP | S_IWGRP);


### PR DESCRIPTION
This fixes possible problems being detected by the CodeQL codescanning workflow.

Problems contained:
  * 27 "Uncontrolled format string" (https://www.securecoding.cert.org/confluence/display/c/FIO30-C.+Exclude+user+input+from+format+strings) warnings which were caused by overly complicated use of `logIT()` function,
  * 2 "Time-of-check time-of-use filesystem race condition" (https://www.securecoding.cert.org/confluence/display/c/FIO01-C.+Be+careful+using+functions+that+use+file+names+for+identification) problems,
  * 1 "Likely overrunning write" problem caused by format string handling integer instead of char

Please be so kind as to test this version.