### PR TITLE
Fix parsing <listen> config option

### DIFF
--- a/src/xmlconfig.c
+++ b/src/xmlconfig.c
@@ -589,7 +589,7 @@ configPtr parseConfig(xmlNodePtr cur)
             }
             (cur->next && (! (cur->next->type == XML_TEXT_NODE) || cur->next->next))
                 ? (cur = cur->next) : (cur = prevPtr->next);
-        } else if (logFound && strstr((char *)cur->name, "listen")) {
+        } else if (netFound && strstr((char *)cur->name, "listen")) {
             chrPtr = getTextNode(cur);
             logIT(LOG_INFO, "   (%d) Node::Name=%s Type:%d Content=%s",
                   cur->line, cur->name, cur->type, chrPtr);


### PR DESCRIPTION
Listen on a specific interface only works when entered on the command line via -L option,
because the <listen> element in xml config is actually handled under the <log> element instead of the <net> element.