### PR TITLE
getTempWWist not working in old Vitodens 300

### DIFF
--- a/xml/300/vito.xml
+++ b/xml/300/vito.xml
@@ -40,6 +40,11 @@
       <len>2</len>
       <unit>UT</unit>
       <description>Ermittle die Warmwassertemperatur in Grad C</description>
+      <device ID="2053">
+        <addr>42</addr>
+        <unit>UT1U</unit>
+        <len>1</len>
+      </device>
     </command>
     <command name="getTempWWsoll" protocmd="getaddr">
       <addr>6300</addr>


### PR DESCRIPTION
After comparing with the KW version, saw that this was missed. I've added it locally and now i get good results from the command now (before 0).