### PR TITLE
Fix #134: Increase max command length in vclient

### DIFF
--- a/src/vclient.c
+++ b/src/vclient.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     // Get the command line options
     char *host = NULL;
     int port = 0;
-    char commands[512] = "";
+    char commands[5120] = "";
     const char *cmdfile = NULL;
     const char *csvfile = NULL;
     const char *tmplfile = NULL;


### PR DESCRIPTION
As reported in issue #134, I was limited by the max length of the command option in vclient, with the current max length being 512, and my command list being 1938 characters long.

This fix #134 by increasing the command max length to 5120, which should be enough to execute all commands at once.

I've tested the fix locally and detected no issue.