### PR TITLE
fix(unit): use correct byte length for enum resolution in procGetUnit

### DIFF
--- a/src/unit.c
+++ b/src/unit.c
@@ -469,8 +469,8 @@ int procGetUnit(unitPtr uPtr, char *recvBuf, int recvLen, char *result, char bit
             return -1;
         }
         logIT(LOG_INFO, "Res: (Hex max. 4 bytes) %08x", ergI);
-        res = ergI;
-        if ( uPtr->ePtr && bytes2Enum(uPtr->ePtr, &res, &tPtr, recvLen)) {
+        res = ergI & 0xFF;  // Use only the lowest byte of ergI as input to enum lookup
+        if (uPtr->ePtr && bytes2Enum(uPtr->ePtr, &res, &tPtr, 1)) {
             strcpy(result, tPtr);
             return 1;
         } else {


### PR DESCRIPTION
This pull request fixes a bug in `procGetUnit` where the result of `execIExpression` (stored in a 4-byte `int`) was passed to `bytes2Enum` using only the *first* byte, but an incorrect length parameter (`recvLen`) was still being used. This led to enum resolution failing or succeeding by coincidence, depending on the content of unrelated bytes.

We now explicitly pass `1` as the byte length to `bytes2Enum`, as only a single byte (`res`) is intended to be used for the lookup.

## Example log from `vcontrold` before the fix

The `getBedarfWarmwasser` is a command that reads in 10 bytes and extracts byte 2 to map it onto an enum.


Command `vito.xml`:
```xml
<command name="getBedarfWarmwasser" protocmd="getaddr">            <!--EventTypeId: 7322-->
    <addr>1185</addr>
    <len>10</len>
    <unit>BEDARF_10B</unit>
    <description>Bedarf Warmwasser</description>
</command>
```

unit in `vcontrold.xml`
```xml
<!-- Bedarf (1 byte at offset 2) -->
<unit name="Bedarf (10 byte)">
	<icalc get="B2"/>
	<abbrev>BEDARF_10B</abbrev>
	<type>uchar</type>
	<enum bytes="00" text="kein Bedarf" />
	<enum bytes="01" text="minimaler Bedarf" />
	<enum bytes="02" text="geringer Bedarf" />
	<enum bytes="03" text="mittlerer Bedarf" />
	<enum bytes="04" text="hoher Bedarf" />
	<enum bytes="05" text="maximaler Bedarf" />
	<enum text="UNKNOWN" />
	<entity></entity>
</unit>
```



After initiating the connection to vcontrold and sending the command, the response is initially parsed correctly:
<details>
  <summary><b>vcontrold log - correctly parsed</b> (click to show)</summary>
 
  ```log
Command: getBedarfWarmwasser
>SENT: 41
>SENT: 05
>SENT: 00
>SENT: 01
>SENT: 11
>SENT: 85
>SENT: 0A
>SENT: A6
<RECV: len=1 06
<RECV: received 06
>FRAMER: framer_set_actaddr framer_current_addr = 8511 (was FFFF)
>FRAMER: Command send
>FRAMER: no preset result
<RECV: len=1 41
<RECV: len=1 0F
<RECV: len=1 01
<RECV: len=1 01
<RECV: len=1 11
<RECV: len=1 85
<RECV: len=1 0A
<RECV: len=1 02
<RECV: len=1 03
<RECV: len=1 00
<RECV: received 41 0F 01 01 11 85 0A 02 03 00
<RECV: len=1 00
<RECV: len=1 F4
<RECV: len=1 01
<RECV: len=1 00
<RECV: len=1 00
<RECV: len=1 80
<RECV: len=1 01
<RECV: len=1 2C
<RECV: received 00 F4 01 00 00 80 01 2C
>FRAMER: framer_reset_actaddr framer_current_addr = FRAMER_NO_ADDR (was 8511)
(INT) Exp: B2 [BP:255] [B0:02 B1:03 B2:00 B3:00 B4:F4 B5:01 B6:00 B7:00 B8:80 B9:01 BA:00 BB:00 BC:00 BD:00 BE:00 BF:00 ]
Res: (Hex max. 4 bytes) 00000000
00 00 00 00 00 00 00 00 00 00 -> kein Bedarf
  ```
  
</details>

After some time, the response is the exact same, but the conversion to enum fails:

<details>
  <summary><b>vcontrold log - parse error</b> (click to show)</summary>
 
  ```log
Command: getBedarfWarmwasser
>SENT: 41
>SENT: 05
>SENT: 00
>SENT: 01
>SENT: 11
>SENT: 85
>SENT: 0A
>SENT: A6
<RECV: len=1 06
<RECV: received 06
>FRAMER: framer_set_actaddr framer_current_addr = 8511 (was FFFF)
>FRAMER: Command send
>FRAMER: no preset result
<RECV: len=1 41
<RECV: len=1 0F
<RECV: len=1 01
<RECV: len=1 01
<RECV: len=1 11
<RECV: len=1 85
<RECV: len=1 0A
<RECV: len=1 02
<RECV: len=1 03
<RECV: len=1 00
<RECV: received 41 0F 01 01 11 85 0A 02 03 00
<RECV: len=1 00
<RECV: len=1 F4
<RECV: len=1 01
<RECV: len=1 00
<RECV: len=1 00
<RECV: len=1 80
<RECV: len=1 01
<RECV: len=1 2C
<RECV: received 00 F4 01 00 00 80 01 2C
>FRAMER: framer_reset_actaddr framer_current_addr = FRAMER_NO_ADDR (was 8511)
(INT) Exp: B2 [BP:255] [B0:02 B1:03 B2:00 B3:00 B4:F4 B5:01 B6:00 B7:00 B8:80 B9:01 BA:00 BB:00 BC:00 BD:00 BE:00 BF:00 ]
Res: (Hex max. 4 bytes) 00000000
00 38 86 72 01 00 00 00 00 00 -> UNKNOWN
  ```
  
</details>

## Reason
The enum lookup sometimes fails due to `recvLen` being passed as `10`, causing `bytes2Enum` to look at 10 bytes instead of 1 in:
```c
if ( uPtr->ePtr && bytes2Enum(uPtr->ePtr, &res, &tPtr, recvLen)) {
```

## Fix

The fix changes:

```c
if ( uPtr->ePtr && bytes2Enum(uPtr->ePtr, &res, &tPtr, recvLen)) {
```

to:

```c
if ( uPtr->ePtr && bytes2Enum(uPtr->ePtr, &res, &tPtr, 1)) {
```

Now the lookup works consistently as expected.
